### PR TITLE
Post-crash deploy-script updates

### DIFF
--- a/releasing/play.md
+++ b/releasing/play.md
@@ -360,20 +360,16 @@ Commit and push your changes.
 
 To set up your public key:
 
-1. Ask someone else from Play team to add your pub key to the website instance.
-2. Edit ~/.ssh/config and add the following:
+1. Ask someone else from Play team to give you access to the `playframework` team on keybase.
+2. Download the PEM file and log into the machine:
 
 ```
- Host www.playframework.com
-  User ubuntu
-  Hostname ???
+ssh -i PlayProd2015.pem ubuntu@ec2-100-25-201-80.compute-1.amazonaws.com
 ```
-
-3. You can now log in: `ssh ubuntu@www.playframework.com`
-4. ssh into `ubuntu@www.playframework.com`
-5. `cd playframework.com`
-6. `git pull`
-7. Restart the linux service: `sudo service playframework restart` // ???
+3. `cd playframework.com`
+4. `git pull`
+5. `sbt stage`
+6. Restart the linux service: `sudo systemctl restart playframework.service`
 
 **Verification**: Check that <https://www.playframework.com/changelog> contains the new release.  
 

--- a/releasing/play.md
+++ b/releasing/play.md
@@ -366,12 +366,14 @@ To set up your public key:
 ```
  Host www.playframework.com
   User ubuntu
-  Hostname 54.173.126.144
+  Hostname ???
 ```
 
 3. You can now log in: `ssh ubuntu@www.playframework.com`
-
-ssh into `ubuntu@www.playframework.com`, and run `./deploy.sh`
+4. ssh into `ubuntu@www.playframework.com`
+5. `cd playframework.com`
+6. `git pull`
+7. Restart the linux service: `sudo service playframework restart` // ???
 
 **Verification**: Check that <https://www.playframework.com/changelog> contains the new release.  
 


### PR DESCRIPTION
On July 14th 2021 (or July 15th, not sure), the AWS machine hosting the EC2 instance running playframework.com failed beyond recovery.

In the recovery process we couldn't find the latest snapshot of the AMI so we had to recover one that requires a slightly different process to deploy the website.